### PR TITLE
Changes suffix removal to strip last `.t*` 

### DIFF
--- a/tbd
+++ b/tbd
@@ -30,7 +30,7 @@ function roots {
 # positives such as ".txt"... It shouldn't cause any problems.
 function strip_ext {
   FILE=$(basename "$1")
-  echo "${FILE%%.t*}"
+  echo "${FILE%.t*}"
 }
 
 if [ -z "${1:-}" ]; then


### PR DESCRIPTION
Changes the bash parameter substitution to match the shortest (i.e. last) matching suffix starting with .t (rather than the longest / first).

Fixes #2 
